### PR TITLE
Typographical error on line 194

### DIFF
--- a/08_q_learn_sim_2.ipynb
+++ b/08_q_learn_sim_2.ipynb
@@ -191,7 +191,7 @@
     "            self.data['sma'] = self.data[self.symbol].rolling(self.window).mean()\n",
     "            self.data['dif'] = self.data[self.symbol] - self.data['sma']\n",
     "            self.data['min'] = self.data[self.symbol].rolling(self.window).min()\n",
-    "            self.data['max'] = self.data[self.symbol].rolling(self.window).min()\n",
+    "            self.data['max'] = self.data[self.symbol].rolling(self.window).max()\n",
     "            self.data['mom'] = self.data['r'].rolling(self.window).mean()\n",
     "            # add your own features\n",
     "            self.data.dropna(inplace=True)\n",


### PR DESCRIPTION
I believe .max() should be called instead of .min() to generate a rolling max feature